### PR TITLE
REFACTOR: Produce from both ipc sockets.

### DIFF
--- a/stream/consumers/broadcaster.go
+++ b/stream/consumers/broadcaster.go
@@ -10,7 +10,7 @@ import (
 )
 
 func NewBroadcasterFactory() stream.ProcessorFactory {
-	return stream.NewConsumerFactory(createBroadcasterConsumer)
+	return stream.NewConsumerFactory(createBroadcasterConsumer, stream.EventTypeConsensus)
 }
 
 func createBroadcasterConsumer(c cfg.Config, _ uint32, chainVM string, chainID string) (indexer services.Consumer, err error) {

--- a/stream/consumers/indexer.go
+++ b/stream/consumers/indexer.go
@@ -12,7 +12,7 @@ import (
 )
 
 func NewIndexerFactory() stream.ProcessorFactory {
-	return stream.NewConsumerFactory(createIndexerConsumer)
+	return stream.NewConsumerFactory(createIndexerConsumer, stream.EventTypeDecisions)
 }
 
 func createIndexerConsumer(conf cfg.Config, networkID uint32, chainVM string, chainID string) (indexer services.Consumer, err error) {

--- a/stream/processor.go
+++ b/stream/processor.go
@@ -126,7 +126,6 @@ func (c *ProcessorManager) runProcessor(chainConfig cfg.Chain) error {
 	// Create a backend to get messages from
 	backend, err := c.factory(c.conf, c.conf.NetworkID, chainConfig.VMType, chainConfig.ID)
 	if err != nil {
-		// panic(err)
 		return err
 	}
 

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -5,11 +5,27 @@ package stream
 
 import (
 	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/ava-labs/gecko/ids"
 )
 
 var (
 	ErrUnknownVM = errors.New("Unknown VM")
+
+	ErrInvalidTopicName    = errors.New("invalid topic name")
+	ErrWrongTopicEventType = errors.New("wrong topic event type")
+	ErrWrongTopicNetworkID = errors.New("wrong topic networkID")
 )
+
+var (
+	EventTypeConsensus EventType = "consensus"
+	EventTypeDecisions EventType = "decisions"
+)
+
+type EventType string
 
 // Message is a message on the event stream
 type Message struct {
@@ -23,3 +39,28 @@ func (m *Message) ID() string       { return m.id }
 func (m *Message) ChainID() string  { return m.chainID }
 func (m *Message) Body() []byte     { return m.body }
 func (m *Message) Timestamp() int64 { return m.timestamp }
+
+func getSocketName(root string, networkID uint32, chainID string, eventType EventType) string {
+	return fmt.Sprintf("ipc://%s/%d-%s-%s", root, networkID, chainID, eventType)
+}
+
+func getTopicName(networkID uint32, chainID string, eventType EventType) string {
+	return fmt.Sprintf("%d-%s-%s", networkID, chainID, eventType)
+}
+
+func parseTopicNameToChainID(topic string, networkID uint32, eventType EventType) (ids.ID, error) {
+	parts := strings.Split(topic, "-")
+	if len(parts) != 3 {
+		return ids.Empty, ErrInvalidTopicName
+	}
+
+	if parts[0] != strconv.Itoa(int(networkID)) {
+		return ids.Empty, ErrWrongTopicNetworkID
+	}
+
+	if parts[2] != string(eventType) {
+		return ids.Empty, ErrWrongTopicEventType
+	}
+
+	return ids.FromString(parts[1])
+}


### PR DESCRIPTION
Gecko is changing to write consensus containers in addition to decision events. It will publish each stream to their own IPC sockets. This PR changes the producer to ingest both streams into Kafka as separate topics.