### PR TITLE
BUGFIX: remove duplicate transactions from list

### DIFF
--- a/services/indexes/avm/db_getters.go
+++ b/services/indexes/avm/db_getters.go
@@ -253,6 +253,7 @@ func (db *DB) ListTransactions(ctx context.Context, p *ListTransactionsParams) (
 	txs := []*Transaction{}
 	builder := p.Apply(dbRunner.
 		Select("avm_transactions.id", "avm_transactions.chain_id", "avm_transactions.type", "HEX(avm_transactions.memo) as memo", "avm_transactions.created_at").
+		Distinct().
 		From("avm_transactions").
 		Where("avm_transactions.chain_id = ?", db.chainID))
 


### PR DESCRIPTION
Running Distinct on the selection row because we only pull items from avm_transactions.* this will return a unique set of responses.