### PR TITLE
BUGFIX: handle EOF restart

### DIFF
--- a/stream/processor.go
+++ b/stream/processor.go
@@ -195,7 +195,7 @@ func (c *ProcessorManager) runProcessorLoop(chainConfig cfg.Chain) error {
 	// Process messages until asked to stop
 	for !c.isStopping() {
 		err := processNextMessage()
-		if err == io.EOF {
+		if err == io.EOF && !c.isStopping() {
 			return err
 		}
 	}


### PR DESCRIPTION
When you receive EOF on the socket, you will continue to receive EOF, and it spams the console with logging messges. If you stop and restart gecko while you are listing on the socket this is reproducable.
Push the processing into a loop so the defer can close the socket, then on EOF, restart the socket connection.
