### PR TITLE
PERF: processor threads

### DIFF
--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -23,6 +23,8 @@ var (
 type Config struct {
 	NetworkID    uint32 `json:"networkID"`
 	LogDirectory string `json:"logDirectory"`
+	QueueSizeConsumer uint32 `json:"queueSizeConsumer"`
+	QueueSizeProducer uint32 `json:"queueSizeProducer"`
 	Chains       `json:"chains"`
 	Stream       `json:"stream"`
 	Services     `json:"services"`
@@ -113,6 +115,8 @@ func NewFromFile(filePath string) (*Config, error) {
 	return &Config{
 		NetworkID:    v.GetUint32(keysNetworkID),
 		LogDirectory: v.GetString(keysLogDirectory),
+		QueueSizeConsumer: v.GetUint32(keysQueueSizeConsumer),
+		QueueSizeProducer: v.GetUint32(keysQueueSizeProducer),
 		Chains:       chains,
 		Services: Services{
 			API: API{

--- a/cfg/keys.go
+++ b/cfg/keys.go
@@ -6,6 +6,8 @@ package cfg
 const (
 	keysNetworkID    = "networkID"
 	keysLogDirectory = "logDirectory"
+	keysQueueSizeConsumer = "queueSizeConsumer"
+	keysQueueSizeProducer = "queueSizeProducer"
 
 	keysChains       = "chains"
 	keysChainsID     = "id"

--- a/docker/config.json
+++ b/docker/config.json
@@ -1,6 +1,8 @@
 {
   "networkID": 4,
   "logDirectory": "/var/log/ortelius",
+  "queueSizeConsumer": 4,
+  "queueSizeProducer": 4,
   "ipcRoot": "ipc:///tmp",
   "listenAddr": "localhost:8080",
   "chains": {

--- a/stream/producer.go
+++ b/stream/producer.go
@@ -9,6 +9,9 @@ import (
 
 	"github.com/ava-labs/avalanchego/ipcs/socket"
 	"github.com/ava-labs/avalanchego/utils/logging"
+	"sync"
+	"sync/atomic"
+
 	"github.com/ava-labs/ortelius/cfg"
 )
 
@@ -19,15 +22,27 @@ type Producer struct {
 	sock        *socket.Client
 	binFilterFn binFilterFn
 	writeBuffer *writeBuffer
+	msgchan     chan<- []byte
+	waitgroup   sync.WaitGroup
+	cancel      context.CancelFunc
+	successes   uint64
+	log         logging.Logger
 }
 
 // NewProducer creates a producer using the given config
-func NewProducer(conf cfg.Config, networkID uint32, _ string, chainID string, eventType EventType) (*Producer, error) {
+func NewProducer(conf cfg.Config, networkID uint32, _ string, chainID string, eventType EventType, log logging.Logger) (*Producer, error) {
+	msgchan := make(chan []byte)
+	ctx, cancel := context.WithCancel(context.Background())
+
 	p := &Producer{
 		chainID:     chainID,
 		eventType:   eventType,
 		binFilterFn: newBinFilterFn(conf.Filter.Min, conf.Filter.Max),
 		writeBuffer: newWriteBuffer(conf.Brokers, GetTopicName(networkID, chainID, eventType)),
+		msgchan:     msgchan,
+		waitgroup:   sync.WaitGroup{},
+		cancel:      cancel,
+		log:         log,
 	}
 
 	var err error
@@ -36,43 +51,67 @@ func NewProducer(conf cfg.Config, networkID uint32, _ string, chainID string, ev
 		return nil, err
 	}
 
+	for i := 0; i < int(conf.QueueSizeProducer); i++ {
+		p.waitgroup.Add(1)
+		go p.ProcessWorker(ctx, msgchan)
+	}
+
 	return p, nil
 }
 
 // NewConsensusProducerProcessor creates a producer for consensus events
-func NewConsensusProducerProcessor(conf cfg.Config, networkID uint32, chainVM string, chainID string) (Processor, error) {
-	return NewProducer(conf, networkID, chainVM, chainID, EventTypeConsensus)
+func NewConsensusProducerProcessor(conf cfg.Config, networkID uint32, chainVM string, chainID string, log logging.Logger) (Processor, error) {
+	return NewProducer(conf, networkID, chainVM, chainID, EventTypeConsensus, log)
 }
 
 // NewDecisionsProducerProcessor creates a producer for decision events
-func NewDecisionsProducerProcessor(conf cfg.Config, networkID uint32, chainVM string, chainID string) (Processor, error) {
-	return NewProducer(conf, networkID, chainVM, chainID, EventTypeDecisions)
+func NewDecisionsProducerProcessor(conf cfg.Config, networkID uint32, chainVM string, chainID string, log logging.Logger) (Processor, error) {
+	return NewProducer(conf, networkID, chainVM, chainID, EventTypeDecisions, log)
 }
 
 // Close shuts down the producer
 func (p *Producer) Close() error {
+	p.cancel()
+	p.waitgroup.Wait()
 	return p.writeBuffer.close()
 }
 
 // ProcessNextMessage takes in a Message from the IPC socket and writes it to
 // Kafka
-func (p *Producer) ProcessNextMessage(_ context.Context, log logging.Logger) error {
+func (p *Producer) ProcessNextMessage(_ context.Context) error {
 	rawMsg, err := p.sock.Recv()
 	if err != nil {
-		log.Error("sock.Recv: %s", err.Error())
+		p.log.Error("sock.Recv: %s", err.Error())
 		return err
 	}
 
-	if p.binFilterFn(rawMsg) {
-		return nil
-	}
+	p.msgchan <- rawMsg
 
-	if _, err = p.writeBuffer.Write(rawMsg); err != nil {
-		log.Error("writeBuffer.Write: %s", err.Error())
-		return err
-	}
 	return nil
 }
+
+func (p *Producer) Successes() uint64 {
+	return p.successes
+}
+
+func (p *Producer) ProcessWorker(ctx context.Context, msgchan <- chan []byte) {
+	defer p.waitgroup.Done()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case rawMsg := <- msgchan:
+			if !p.binFilterFn(rawMsg) {
+				if _, err := p.writeBuffer.Write(rawMsg); err != nil {
+					p.log.Error("writeBuffer.Write: %s", err.Error())
+				} else {
+					atomic.AddUint64(&p.successes, 1)
+				}
+			}
+		}
+	}
+}
+
 
 func (p *Producer) Write(msg []byte) (int, error) {
 	return p.writeBuffer.Write(msg)


### PR DESCRIPTION
The idea here is to improve performance.

If we consume from the socket, we can pipe into a series of threads that will parse and push the message to kafka.
The speed up is in the processing message.

The same for the producer, we save some time by parallel processing the hashes.

@tyler-smith  Curious your thoughts.