### PR TITLE
BUGFIX: fix threshold

### DIFF
--- a/services/indexes/avm/db_writers.go
+++ b/services/indexes/avm/db_writers.go
@@ -318,7 +318,22 @@ func (db *DB) ingestOutput(ctx services.ConsumerCtx, txID ids.ID, idx uint32, as
 		Pair("threshold", out.Threshold).
 		ExecContext(ctx.Ctx())
 	if err != nil && !errIsDuplicateEntryError(err) {
-		_ = db.stream.EventErr("ingest_output", err)
+		_, err := ctx.DB().
+			Update("avm_outputs").
+			Set("chain_id", db.chainID).
+			Set("transaction_id", txID.String()).
+			Set("output_index", idx).
+			Set("asset_id", assetID.String()).
+			Set("output_type", OutputTypesSECP2556K1Transfer).
+			Set("amount", out.Amount()).
+			Set("created_at", ctx.Time()).
+			Set("locktime", out.Locktime).
+			Set("threshold", out.Threshold).
+			Where("avm_outputs.id = ?", outputID.String()).
+			ExecContext(ctx.Ctx())
+		if err != nil {
+			_ = db.stream.EventErr("ingest_output", err)
+		}
 	}
 
 	// Ingest each Output Address


### PR DESCRIPTION
Taking a bit of a guess here...

From the code here:
https://github.com/ava-labs/ortelius/blob/0a18147c1974a22f11c9f8ac6db42eb89216bd3c/services/indexes/avm/db_writers.go#L237

A holder output is created.  And the threshhold is set to 0.  But if we see the output later here:
https://github.com/ava-labs/ortelius/blob/0a18147c1974a22f11c9f8ac6db42eb89216bd3c/services/indexes/avm/db_writers.go#L299

The row is considered a duplicate..  So it won't update the threshold.
