### PR TITLE
BUGFIX: Fix OutputType for secp txs to be 7.

### DIFF
--- a/services/indexes/avm/models.go
+++ b/services/indexes/avm/models.go
@@ -12,7 +12,7 @@ import (
 var (
 	VMName = "avm"
 
-	OutputTypesSECP2556K1Transfer OutputType = 0x000000ff
+	OutputTypesSECP2556K1Transfer OutputType = 7
 
 	TXTypeBase        TransactionType = "base"
 	TXTypeCreateAsset TransactionType = "create_asset"


### PR DESCRIPTION
The correct canonical type id for this is 7, not 0xff.