### PR TITLE
Revert "TWEAK: Allow parsing large genesis transactions."

### DIFF
--- a/services/indexes/avm/index.go
+++ b/services/indexes/avm/index.go
@@ -6,7 +6,6 @@ package avm
 import (
 	"context"
 	"errors"
-	"math"
 
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/database/nodb"
@@ -76,7 +75,7 @@ func (i *Index) Bootstrap(ctx context.Context) error {
 	}
 
 	platformGenesis := &platformvm.Genesis{}
-	if err = platformvm.GenesisCodec.Unmarshal(platformGenesisBytes, platformGenesis); err != nil {
+	if err = platformvm.Codec.Unmarshal(platformGenesisBytes, platformGenesis); err != nil {
 		return err
 	}
 	if err = platformGenesis.Initialize(); err != nil {
@@ -250,9 +249,6 @@ func newAVM(chainID ids.ID, networkID uint32) (*avm.VM, error) {
 	if err != nil && err != database.ErrClosed {
 		return nil, err
 	}
-
-	vm.Codec().SetMaxSize(math.MaxUint32)
-	vm.Codec().SetMaxSliceLen(math.MaxUint32)
 
 	return vm, nil
 }

--- a/stream/consumer.go
+++ b/stream/consumer.go
@@ -45,7 +45,7 @@ func NewConsumerFactory(factory serviceConsumerFactory, eventType EventType) Pro
 		}
 
 		// Bootstrap our service
-		ctx, cancelFn := context.WithTimeout(context.Background(), 1*time.Minute)
+		ctx, cancelFn := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancelFn()
 		if err = c.consumer.Bootstrap(ctx); err != nil {
 			return nil, err


### PR DESCRIPTION
This reverts commit 01e76eebaa8215d814fba530bc18b1b0ee36bea9.

These new Codec features are not yet in mainlet; reverting until they are.