### PR TITLE
p chain fixes

### DIFF
--- a/services/indexes/avax/writer.go
+++ b/services/indexes/avax/writer.go
@@ -4,12 +4,16 @@
 package avax
 
 import (
+	"fmt"
+	"reflect"
+
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/crypto"
 	"github.com/ava-labs/avalanchego/utils/math"
 	"github.com/ava-labs/avalanchego/utils/wrappers"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/components/verify"
+	"github.com/ava-labs/avalanchego/vms/platformvm"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/gocraft/dbr/v2"
 	"github.com/gocraft/health"
@@ -116,11 +120,23 @@ func (w *Writer) InsertTransaction(ctx services.ConsumerCtx, txBytes []byte, uns
 
 	// Process baseTx outputs by adding to the outputs table
 	for idx, out := range append(baseTx.Outs, addOuts...) {
-		xOut, ok := out.Output().(*secp256k1fx.TransferOutput)
-		if !ok {
+		// there will be empty outs inserted to make sure the idx is correct.
+		if out == nil {
 			continue
 		}
-		errs.Add(w.InsertOutput(ctx, baseTx.ID(), uint32(idx), out.AssetID(), xOut, models.OutputTypesSECP2556K1Transfer, 0, nil))
+		switch transferOutput := out.Out.(type) {
+		case *platformvm.StakeableLockOut:
+			xOut, ok := transferOutput.TransferableOut.(*secp256k1fx.TransferOutput)
+			if !ok {
+				return fmt.Errorf("invalid output *secp256k1fx.TransferOutput")
+			}
+			xOut.Locktime = transferOutput.Locktime
+			errs.Add(w.InsertOutput(ctx, baseTx.ID(), uint32(idx), out.AssetID(), xOut, models.OutputTypesSECP2556K1Transfer, 0, nil))
+		case *secp256k1fx.TransferOutput:
+			errs.Add(w.InsertOutput(ctx, baseTx.ID(), uint32(idx), out.AssetID(), transferOutput, models.OutputTypesSECP2556K1Transfer, 0, nil))
+		default:
+			errs.Add(fmt.Errorf("unknown type %s", reflect.TypeOf(transferOutput)))
+		}
 	}
 	return errs.Err
 }

--- a/services/indexes/avax/writer.go
+++ b/services/indexes/avax/writer.go
@@ -128,7 +128,7 @@ func (w *Writer) InsertTransaction(ctx services.ConsumerCtx, txBytes []byte, uns
 		case *platformvm.StakeableLockOut:
 			xOut, ok := transferOutput.TransferableOut.(*secp256k1fx.TransferOutput)
 			if !ok {
-				return fmt.Errorf("invalid output *secp256k1fx.TransferOutput")
+				return fmt.Errorf("invalid type *secp256k1fx.TransferOutput")
 			}
 			xOut.Locktime = transferOutput.Locktime
 			errs.Add(w.InsertOutput(ctx, baseTx.ID(), uint32(idx), out.AssetID(), xOut, models.OutputTypesSECP2556K1Transfer, 0, nil))

--- a/services/indexes/avax/writer.go
+++ b/services/indexes/avax/writer.go
@@ -120,17 +120,14 @@ func (w *Writer) InsertTransaction(ctx services.ConsumerCtx, txBytes []byte, uns
 
 	// Process baseTx outputs by adding to the outputs table
 	for idx, out := range append(baseTx.Outs, addOuts...) {
-		// there will be empty outs inserted to make sure the idx is correct.
-		if out == nil {
-			continue
-		}
 		switch transferOutput := out.Out.(type) {
 		case *platformvm.StakeableLockOut:
 			xOut, ok := transferOutput.TransferableOut.(*secp256k1fx.TransferOutput)
 			if !ok {
 				return fmt.Errorf("invalid type *secp256k1fx.TransferOutput")
 			}
-			xOut.Locktime = transferOutput.Locktime
+			// needs to support StakeableLockOut Locktime...
+			// xOut.Locktime = transferOutput.Locktime
 			errs.Add(w.InsertOutput(ctx, baseTx.ID(), uint32(idx), out.AssetID(), xOut, models.OutputTypesSECP2556K1Transfer, 0, nil))
 		case *secp256k1fx.TransferOutput:
 			errs.Add(w.InsertOutput(ctx, baseTx.ID(), uint32(idx), out.AssetID(), transferOutput, models.OutputTypesSECP2556K1Transfer, 0, nil))

--- a/services/indexes/avm/writer.go
+++ b/services/indexes/avm/writer.go
@@ -238,9 +238,9 @@ func (w *Writer) insertCreateAssetTx(ctx services.ConsumerCtx, txBytes []byte, t
 	}
 
 	for _, txOut := range tx.Outs {
-		switch xOut := txOut.Out.(type) {
+		switch xOutOut := txOut.Out.(type) {
 		case *secp256k1fx.TransferOutput:
-			errs.Add(w.avax.InsertOutput(ctx, tx.ID(), outputCount, tx.ID(), xOut, models.OutputTypesSECP2556K1Transfer, 0, nil))
+			errs.Add(w.avax.InsertOutput(ctx, tx.ID(), outputCount, tx.ID(), xOutOut, models.OutputTypesSECP2556K1Transfer, 0, nil))
 		default:
 			_ = ctx.Job().EventErr("assertion_to_output", errors.New("output is not known"))
 		}

--- a/services/indexes/avm/writer.go
+++ b/services/indexes/avm/writer.go
@@ -6,12 +6,15 @@ package avm
 import (
 	"context"
 	"errors"
+	"fmt"
+	"reflect"
 
 	"github.com/ava-labs/avalanchego/genesis"
 	"github.com/ava-labs/avalanchego/utils/codec"
 	avalancheMath "github.com/ava-labs/avalanchego/utils/math"
 	"github.com/ava-labs/avalanchego/utils/wrappers"
 	"github.com/ava-labs/avalanchego/vms/avm"
+	avalancheAvax "github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/components/verify"
 	"github.com/ava-labs/avalanchego/vms/nftfx"
 	"github.com/ava-labs/avalanchego/vms/platformvm"
@@ -186,7 +189,29 @@ func (w *Writer) insertTx(ctx services.ConsumerCtx, txBytes []byte) error {
 	case *avm.CreateAssetTx:
 		return w.insertCreateAssetTx(ctx, txBytes, castTx, tx.Credentials(), "")
 	case *avm.OperationTx:
-		return w.avax.InsertTransaction(ctx, txBytes, unsignedBytes, &castTx.BaseTx.BaseTx, tx.Credentials(), models.TransactionTypeOperation, nil, nil)
+		addlOuts := make([]*avalancheAvax.TransferableOutput, 0, 1)
+		for _, castTxOps := range castTx.Ops {
+			for _, castTxOpsOpOut := range castTxOps.Op.Outs() {
+				var transferableOutput avalancheAvax.TransferableOutput
+				transferableOutput.Asset = castTxOps.Asset
+				switch castTxOpsOpOutVal := castTxOpsOpOut.(type) {
+				case *secp256k1fx.TransferOutput:
+					transferableOutput.Out = castTxOpsOpOutVal
+				case *nftfx.TransferOutput:
+					var secpTo secp256k1fx.TransferOutput
+					secpTo.OutputOwners = castTxOpsOpOutVal.OutputOwners
+					transferableOutput.Out = &secpTo
+				case *secp256k1fx.MintOutput:
+					var secpTo secp256k1fx.TransferOutput
+					secpTo.OutputOwners = castTxOpsOpOutVal.OutputOwners
+					transferableOutput.Out = &secpTo
+				default:
+					return fmt.Errorf("unknown type %s", reflect.TypeOf(castTxOpsOpOut))
+				}
+				addlOuts = append(addlOuts, &transferableOutput)
+			}
+		}
+		return w.avax.InsertTransaction(ctx, txBytes, unsignedBytes, &castTx.BaseTx.BaseTx, tx.Credentials(), models.TransactionTypeOperation, nil, addlOuts)
 	case *avm.ImportTx:
 		return w.avax.InsertTransaction(ctx, txBytes, unsignedBytes, &castTx.BaseTx.BaseTx, tx.Credentials(), models.TransactionTypeAVMImport, castTx.ImportedIns, nil)
 	case *avm.ExportTx:
@@ -210,6 +235,16 @@ func (w *Writer) insertCreateAssetTx(ctx services.ConsumerCtx, txBytes []byte, t
 
 	xOut := func(oo secp256k1fx.OutputOwners) *secp256k1fx.TransferOutput {
 		return &secp256k1fx.TransferOutput{OutputOwners: oo}
+	}
+
+	for _, txOut := range tx.Outs {
+		switch xOut := txOut.Out.(type) {
+		case *secp256k1fx.TransferOutput:
+			errs.Add(w.avax.InsertOutput(ctx, tx.ID(), outputCount, tx.ID(), xOut, models.OutputTypesSECP2556K1Transfer, 0, nil))
+		default:
+			_ = ctx.Job().EventErr("assertion_to_output", errors.New("output is not known"))
+		}
+		outputCount++
 	}
 
 	for _, state := range tx.States {

--- a/services/indexes/avm/writer.go
+++ b/services/indexes/avm/writer.go
@@ -240,7 +240,7 @@ func (w *Writer) insertCreateAssetTx(ctx services.ConsumerCtx, txBytes []byte, t
 	for _, txOut := range tx.Outs {
 		switch xOutOut := txOut.Out.(type) {
 		case *secp256k1fx.TransferOutput:
-			errs.Add(w.avax.InsertOutput(ctx, tx.ID(), outputCount, tx.ID(), xOutOut, models.OutputTypesSECP2556K1Transfer, 0, nil))
+			errs.Add(w.avax.InsertOutput(ctx, tx.ID(), outputCount, txOut.AssetID(), xOutOut, models.OutputTypesSECP2556K1Transfer, 0, nil))
 		default:
 			_ = ctx.Job().EventErr("assertion_to_output", errors.New("output is not known"))
 		}

--- a/services/indexes/pvm/writer.go
+++ b/services/indexes/pvm/writer.go
@@ -105,7 +105,8 @@ func (w *Writer) Bootstrap(ctx context.Context) error {
 			if !ok {
 				return fmt.Errorf("invalid type *secp256k1fx.TransferOutput")
 			}
-			xOut.Locktime = transferOutput.Locktime
+			// needs to support StakeableLockOut Locktime...
+			// xOut.Locktime = transferOutput.Locktime
 			errs.Add(w.avax.InsertOutput(cCtx, ChainID, uint32(idx), utxo.AssetID(), xOut, models.OutputTypesSECP2556K1Transfer, 0, nil))
 		case *secp256k1fx.TransferOutput:
 			errs.Add(w.avax.InsertOutput(cCtx, ChainID, uint32(idx), utxo.AssetID(), transferOutput, models.OutputTypesSECP2556K1Transfer, 0, nil))

--- a/services/indexes/pvm/writer.go
+++ b/services/indexes/pvm/writer.go
@@ -107,6 +107,8 @@ func (w *Writer) Bootstrap(ctx context.Context) error {
 			}
 			xOut.Locktime = transferOutput.Locktime
 			errs.Add(w.avax.InsertOutput(cCtx, ChainID, uint32(idx), utxo.AssetID(), xOut, models.OutputTypesSECP2556K1Transfer, 0, nil))
+		case *secp256k1fx.TransferOutput:
+			errs.Add(w.avax.InsertOutput(cCtx, ChainID, uint32(idx), utxo.AssetID(), transferOutput, models.OutputTypesSECP2556K1Transfer, 0, nil))
 		default:
 			return fmt.Errorf("invalid type %s", reflect.TypeOf(transferOutput))
 		}


### PR DESCRIPTION
Since the prefix of CreateAsset, Operation we need to wipe the avm_outputs (and maybe the avm_output_address tables.  B/c we don't update the records, and the old/bad Output indexes would be offset by a few items, and the Amount would be wrong.

Not processing rewards is still causes some missing redeems.

Depending on how the items were written to Kafka a single re-index could still have discrepancies.  It just depends on getting an In without having processed the Out.  And that could happen b/c of threads in node or in producer.

I think we should go with [PR-110](https://github.com/ava-labs/ortelius/pull/110)
