### PR TITLE
establish a session timeout

### DIFF
--- a/services/db/db.go
+++ b/services/db/db.go
@@ -46,7 +46,7 @@ func (c *Conn) Close(context.Context) error {
 }
 
 func (c *Conn) NewSession(name string, timeout time.Duration) (*dbr.Session, error) {
-	session := c.conn.NewSession(c.stream.NewJob(name))
+	session := c.NewSessionForEventReceiver(c.stream.NewJob(name))
 	if _, err := session.Exec(fmt.Sprintf("SET SESSION MAX_EXECUTION_TIME=%d", timeout.Milliseconds())); err != nil {
 		return nil, err
 	}

--- a/services/indexes/avm/reader.go
+++ b/services/indexes/avm/reader.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/ava-labs/ortelius/api"
 	"math"
 	"math/big"
 	"time"
@@ -15,6 +14,7 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/gocraft/dbr/v2"
 
+	"github.com/ava-labs/ortelius/api"
 	"github.com/ava-labs/ortelius/services"
 	"github.com/ava-labs/ortelius/services/indexes/models"
 	"github.com/ava-labs/ortelius/services/indexes/params"


### PR DESCRIPTION
When using the readers set a timeout on the session to match the go timeout.
Keeps the DB from running longer than allocated time eating up resources we will never be able to use.