### PR TITLE
Tweak: Pre extend redeeming

### DIFF
--- a/services/db/migrations/012_add_fields_redeeming.down.sql
+++ b/services/db/migrations/012_add_fields_redeeming.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `avm_outputs_redeeming` DROP COLUMN `intx`;
+ALTER TABLE `avm_outputs_redeeming` DROP COLUMN `asset_id`;

--- a/services/db/migrations/012_add_fields_redeeming.up.sql
+++ b/services/db/migrations/012_add_fields_redeeming.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `avm_outputs_redeeming` ADD COLUMN `intx` varchar(50) default null;
+ALTER TABLE `avm_outputs_redeeming` ADD COLUMN `asset_id` varchar(50) default null;

--- a/services/indexes/avax/writer.go
+++ b/services/indexes/avax/writer.go
@@ -76,13 +76,6 @@ func (w *Writer) InsertTransaction(ctx services.ConsumerCtx, txBytes []byte, uns
 			errs.Add(err)
 		}
 
-		// Upsert this input as an output in case we haven't seen the parent tx
-		// We leave Addrs blank because we inserted them above with their signatures
-		// w.InsertOutput(ctx, in.UTXOID.TxID, in.UTXOID.OutputIndex, in.AssetID(), &secp256k1fx.TransferOutput{
-		// 	Amt:          in.In.Amount(),
-		// 	OutputOwners: secp256k1fx.OutputOwners{},
-		// }, models.OutputTypesSECP2556K1Transfer, 0, nil)
-
 		// For each signature we recover the public key and the data to the db
 		cred, _ := creds[i].(*secp256k1fx.Credential)
 		for _, sig := range cred.Sigs {

--- a/services/indexes/avax/writer.go
+++ b/services/indexes/avax/writer.go
@@ -68,6 +68,8 @@ func (w *Writer) InsertTransaction(ctx services.ConsumerCtx, txBytes []byte, uns
 			Pair("redeeming_transaction_id", baseTx.ID().String()).
 			Pair("amount", in.Input().Amount()).
 			Pair("output_index", in.OutputIndex).
+			Pair("intx", in.TxID.String()).
+			Pair("asset_id", in.AssetID().String()).
 			Pair("created_at", ctx.Time()).
 			ExecContext(ctx.Ctx())
 		if err != nil && !db.ErrIsDuplicateEntryError(err) {

--- a/services/indexes/avm/reader.go
+++ b/services/indexes/avm/reader.go
@@ -984,27 +984,3 @@ func selectOutputs(dbRunner dbr.SessionRunner) *dbr.SelectBuilder {
 		LeftJoin("avm_outputs_redeeming", "avm_outputs.id = avm_outputs_redeeming.id").
 		LeftJoin("addresses", "addresses.address = avm_output_addresses.address")
 }
-
-// match selectOutputs but based from avm_outputs_redeeming
-func selectOutputsRedeeming(dbRunner dbr.SessionRunner) *dbr.SelectBuilder {
-	return dbRunner.Select("avm_outputs_redeeming.id",
-		"avm_outputs_redeeming.intx as transaction_id",
-		"avm_outputs_redeeming.output_index",
-		"avm_outputs_redeeming.asset_id",
-		"case when avm_outputs.output_type is null then 0 else avm_outputs.output_type end as output_type",
-		"avm_outputs_redeeming.amount",
-		"case when avm_outputs.locktime is null then 0 else avm_outputs.locktime end as locktime",
-		"case when avm_outputs.threshold is null then 0 else avm_outputs.threshold end as threshold",
-		"avm_outputs_redeeming.created_at",
-		"case when avm_outputs_redeeming.redeeming_transaction_id IS NULL then '' else avm_outputs_redeeming.redeeming_transaction_id end as redeeming_transaction_id",
-		"case when avm_outputs.group_id is null then 0 else avm_outputs.group_id end as group_id",
-		"case when avm_output_addresses.output_id is null then '' else avm_output_addresses.output_id end AS output_id",
-		"case when avm_output_addresses.address is null then '' else avm_output_addresses.address end AS address",
-		"avm_output_addresses.redeeming_signature AS signature",
-		"addresses.public_key AS public_key",
-	).
-		From("avm_outputs_redeeming").
-		LeftJoin("avm_outputs", "avm_outputs_redeeming.id = avm_outputs.id").
-		LeftJoin("avm_output_addresses", "avm_outputs.id = avm_output_addresses.output_id").
-		LeftJoin("addresses", "addresses.address = avm_output_addresses.address")
-}

--- a/services/indexes/avm/reader.go
+++ b/services/indexes/avm/reader.go
@@ -1019,7 +1019,7 @@ func selectOutputsRedeeming(dbRunner dbr.SessionRunner) *dbr.SelectBuilder {
 		"addresses.public_key AS public_key",
 	).
 		From("avm_outputs_redeeming").
-		LeftJoin("avm_output_addresses", "avm_outputs.id = avm_output_addresses.output_id").
 		LeftJoin("avm_outputs", "avm_outputs_redeeming.id = avm_outputs.id").
+		LeftJoin("avm_output_addresses", "avm_outputs.id = avm_output_addresses.output_id").
 		LeftJoin("addresses", "addresses.address = avm_output_addresses.address")
 }

--- a/services/indexes/avm/reader.go
+++ b/services/indexes/avm/reader.go
@@ -1002,7 +1002,7 @@ func selectOutputs(dbRunner dbr.SessionRunner) *dbr.SelectBuilder {
 
 // match selectOutputs but based from avm_outputs_redeeming
 func selectOutputsRedeeming(dbRunner dbr.SessionRunner) *dbr.SelectBuilder {
-	return dbRunner.Select("avm_outputs.id",
+	return dbRunner.Select("avm_outputs_redeeming.id",
 		"avm_outputs_redeeming.intx",
 		"avm_outputs_redeeming.output_index",
 		"avm_outputs_redeeming.asset_id",

--- a/services/indexes/avm/reader.go
+++ b/services/indexes/avm/reader.go
@@ -605,6 +605,14 @@ func (r *Reader) getFirstTransactionTime(ctx context.Context, chainIDs []string)
 	return time.Unix(ts, 0).UTC(), nil
 }
 
+// Load output data for all inputs and outputs into a single list
+// We can't treat them separately because some my be both inputs and outputs
+// for different transactions
+type compositeRecord struct {
+	models.Output
+	models.OutputAddress
+}
+
 func (r *Reader) dressTransactions(ctx context.Context, dbRunner dbr.SessionRunner, txs []*models.Transaction, avaxAssetID ids.ID, txID *ids.ID, disableGenesis bool) error {
 	if len(txs) == 0 {
 		return nil
@@ -619,54 +627,10 @@ func (r *Reader) dressTransactions(ctx context.Context, dbRunner dbr.SessionRunn
 		txIDs[i] = tx.ID
 	}
 
-	// Load output data for all inputs and outputs into a single list
-	// We can't treat them separately because some my be both inputs and outputs
-	// for different transactions
-	type compositeRecord struct {
-		models.Output
-		models.OutputAddress
-	}
-
-	var outputs []*compositeRecord
-	_, err := selectOutputs(dbRunner).
-		Where("avm_outputs.transaction_id IN ?", txIDs).
-		LoadContext(ctx, &outputs)
+	outputs, err := r.collectInsAndOuts(ctx, dbRunner, txIDs)
 	if err != nil {
 		return err
 	}
-
-	var inputs []*compositeRecord
-	_, err = selectOutputsRedeeming(dbRunner).
-		Where("avm_outputs_redeeming.redeeming_transaction_id IN ?", txIDs).
-		LoadContext(ctx, &inputs)
-	if err != nil {
-		return err
-	}
-
-	var inputsRedeeming []*compositeRecord
-	_, err = selectOutputsRedeeming(dbRunner).
-		Where("avm_outputs_redeeming.redeeming_transaction_id IN ?", txIDs).
-		LoadContext(ctx, &inputsRedeeming)
-	if err != nil {
-		return err
-	}
-
-	// add in missing redeeming rows
-	// these are from genesis txs.
-	for _, input := range inputsRedeeming {
-		found := false
-		for _, input2 := range inputs {
-			if input.ID.Equals(input2.ID) {
-				found = true
-				break
-			}
-		}
-		if !found {
-			inputs = append(inputs, input)
-		}
-	}
-
-	outputs = append(outputs, inputs...)
 
 	// Create a map of addresses for each output and maps of transaction ids to
 	// inputs, outputs, and the total amounts of the inputs and outputs
@@ -773,6 +737,50 @@ func (r *Reader) dressTransactions(ctx context.Context, dbRunner dbr.SessionRunn
 		}
 	}
 	return nil
+}
+
+func (r *Reader) collectInsAndOuts(ctx context.Context, dbRunner dbr.SessionRunner, txIDs []models.StringID) ([]*compositeRecord, error) {
+	var outputs []*compositeRecord
+	_, err := selectOutputs(dbRunner).
+		Where("avm_outputs.transaction_id IN ?", txIDs).
+		LoadContext(ctx, &outputs)
+	if err != nil {
+		return nil, err
+	}
+
+	var inputs []*compositeRecord
+	_, err = selectOutputsRedeeming(dbRunner).
+		Where("avm_outputs_redeeming.redeeming_transaction_id IN ?", txIDs).
+		LoadContext(ctx, &inputs)
+	if err != nil {
+		return nil, err
+	}
+
+	var inputsRedeeming []*compositeRecord
+	_, err = selectOutputsRedeeming(dbRunner).
+		Where("avm_outputs_redeeming.redeeming_transaction_id IN ?", txIDs).
+		LoadContext(ctx, &inputsRedeeming)
+	if err != nil {
+		return nil, err
+	}
+
+	// add in missing redeeming rows
+	// these are from genesis txs.
+	for _, input := range inputsRedeeming {
+		found := false
+		for _, input2 := range inputs {
+			if input.ID.Equals(input2.ID) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			inputs = append(inputs, input)
+		}
+	}
+
+	outputs = append(outputs, inputs...)
+	return outputs, nil
 }
 
 func (r *Reader) dressAddresses(ctx context.Context, dbRunner dbr.SessionRunner, addrs []*models.AddressInfo, version int) error {

--- a/services/indexes/avm/reader.go
+++ b/services/indexes/avm/reader.go
@@ -756,27 +756,29 @@ func (r *Reader) collectInsAndOuts(ctx context.Context, dbRunner dbr.SessionRunn
 		return nil, err
 	}
 
-	var inputsRedeeming []*compositeRecord
-	_, err = selectOutputsRedeeming(dbRunner).
-		Where("avm_outputs_redeeming.redeeming_transaction_id IN ?", txIDs).
-		Where("avm_outputs.id is null").
-		LoadContext(ctx, &inputsRedeeming)
-	if err != nil {
-		return nil, err
-	}
-
-	// add in missing redeeming rows
-	// these are from genesis txs.
-	for _, input := range inputsRedeeming {
-		found := false
-		for _, input2 := range inputs {
-			if input.ID.Equals(input2.ID) {
-				found = true
-				break
-			}
+	if false {
+		var inputsRedeeming []*compositeRecord
+		_, err = selectOutputsRedeeming(dbRunner).
+			Where("avm_outputs_redeeming.redeeming_transaction_id IN ?", txIDs).
+			Where("avm_outputs.id is null").
+			LoadContext(ctx, &inputsRedeeming)
+		if err != nil {
+			return nil, err
 		}
-		if !found {
-			inputs = append(inputs, input)
+
+		// add in missing redeeming rows
+		// these are from genesis txs.
+		for _, input := range inputsRedeeming {
+			found := false
+			for _, input2 := range inputs {
+				if input.ID.Equals(input2.ID) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				inputs = append(inputs, input)
+			}
 		}
 	}
 

--- a/services/indexes/avm/reader.go
+++ b/services/indexes/avm/reader.go
@@ -756,32 +756,6 @@ func (r *Reader) collectInsAndOuts(ctx context.Context, dbRunner dbr.SessionRunn
 		return nil, err
 	}
 
-	if false {
-		var inputsRedeeming []*compositeRecord
-		_, err = selectOutputsRedeeming(dbRunner).
-			Where("avm_outputs_redeeming.redeeming_transaction_id IN ?", txIDs).
-			Where("avm_outputs.id is null").
-			LoadContext(ctx, &inputsRedeeming)
-		if err != nil {
-			return nil, err
-		}
-
-		// add in missing redeeming rows
-		// these are from genesis txs.
-		for _, input := range inputsRedeeming {
-			found := false
-			for _, input2 := range inputs {
-				if input.ID.Equals(input2.ID) {
-					found = true
-					break
-				}
-			}
-			if !found {
-				inputs = append(inputs, input)
-			}
-		}
-	}
-
 	outputs = append(outputs, inputs...)
 	return outputs, nil
 }

--- a/services/indexes/models/primitives.go
+++ b/services/indexes/models/primitives.go
@@ -60,6 +60,15 @@ func (addr Address) Equals(oAddr2 Address) bool {
 
 // MarshalJSON encodes an Address to JSON by converting it to bech32.
 func (addr Address) MarshalJSON() ([]byte, error) {
+	if len(addr) == 0 {
+		bech32Addr, err := formatting.FormatBech32(bech32HRP, ids.ShortEmpty.Bytes())
+		if err != nil {
+			return nil, err
+		}
+
+		return json.Marshal(bech32Addr)
+	}
+
 	id, err := ids.ShortFromString(string(addr))
 	if err != nil {
 		return nil, err

--- a/services/indexes/models/primitives.go
+++ b/services/indexes/models/primitives.go
@@ -60,15 +60,6 @@ func (addr Address) Equals(oAddr2 Address) bool {
 
 // MarshalJSON encodes an Address to JSON by converting it to bech32.
 func (addr Address) MarshalJSON() ([]byte, error) {
-	if len(addr) == 0 {
-		bech32Addr, err := formatting.FormatBech32(bech32HRP, ids.ShortEmpty.Bytes())
-		if err != nil {
-			return nil, err
-		}
-
-		return json.Marshal(bech32Addr)
-	}
-
 	id, err := ids.ShortFromString(string(addr))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Add intx and asset_id from input records in avm_outputs_redeeming.

Pre work for showing genesis tx's.

This tx on prod is not showing inputs.  There are redeeming_tx's fo 2hZBVMu45urgadzyiWxVARVbLLodJ117JJxxWYA2sSdyy9WjwX.

![image](https://user-images.githubusercontent.com/67973730/97588759-369d3b80-19d3-11eb-92ee-fe83e5b83f1f.png)

