### PR TITLE
Tweak: Truncate start/end time to 1 seconds

### DIFF
--- a/services/indexes/avm/reader.go
+++ b/services/indexes/avm/reader.go
@@ -216,9 +216,14 @@ func (r *Reader) Aggregate(ctx context.Context, params *params.AggregateParams) 
 		if len(intervals) > 0 {
 			intervals[0].StartTime = params.StartTime
 			intervals[0].EndTime = params.EndTime
-			return &models.AggregatesHistogram{Aggregates: intervals[0]}, nil
+			return &models.AggregatesHistogram{Aggregates: intervals[0],
+					StartTime: params.StartTime,
+					EndTime:   params.EndTime},
+				nil
 		}
-		return &models.AggregatesHistogram{}, nil
+		return &models.AggregatesHistogram{StartTime: params.StartTime,
+				EndTime: params.EndTime},
+			nil
 	}
 
 	// We need to return multiple intervals so build them now.
@@ -286,6 +291,9 @@ func (r *Reader) Aggregate(ctx context.Context, params *params.AggregateParams) 
 	// Add any missing trailing intervals
 	aggs.Intervals = padTo(aggs.Intervals, requestedIntervalCount)
 
+	aggs.StartTime = params.StartTime
+	aggs.EndTime = params.EndTime
+
 	return aggs, nil
 }
 
@@ -343,7 +351,11 @@ func (r *Reader) ListTransactions(ctx context.Context, p *params.ListTransaction
 		return nil, err
 	}
 
-	return &models.TransactionList{ListMetadata: models.ListMetadata{Count: count}, Transactions: txs}, nil
+	return &models.TransactionList{ListMetadata: models.ListMetadata{Count: count},
+			Transactions: txs,
+			StartTime:    p.StartTime,
+			EndTime:      p.EndTime},
+		nil
 }
 
 func (r *Reader) ListAssets(ctx context.Context, p *params.ListAssetsParams) (*models.AssetList, error) {

--- a/services/indexes/models/collections.go
+++ b/services/indexes/models/collections.go
@@ -14,6 +14,12 @@ type ListMetadata struct {
 type TransactionList struct {
 	ListMetadata
 	Transactions []*Transaction `json:"transactions"`
+
+	// the calculated start time rounded to the nearest TransactionRoundDuration.
+	StartTime time.Time `json:"startTime"`
+
+	// the calculated end time rounded to the nearest TransactionRoundDuration.
+	EndTime time.Time `json:"endTime"`
 }
 
 type AssetList struct {
@@ -57,6 +63,12 @@ type AggregatesHistogram struct {
 	Aggregates   Aggregates    `json:"aggregates"`
 	IntervalSize time.Duration `json:"intervalSize,omitempty"`
 	Intervals    []Aggregates  `json:"intervals,omitempty"`
+
+	// the calculated start time rounded to the nearest TransactionRoundDuration.
+	StartTime time.Time `json:"startTime"`
+
+	// the calculated end time rounded to the nearest TransactionRoundDuration.
+	EndTime time.Time `json:"endTime"`
 }
 
 type Aggregates struct {

--- a/services/indexes/params/collections.go
+++ b/services/indexes/params/collections.go
@@ -77,6 +77,7 @@ func (p *AggregateParams) ForValues(q url.Values) (err error) {
 	if err != nil {
 		return err
 	}
+	p.StartTime = p.StartTime.Round(TransactionRoundDuration)
 
 	p.EndTime, err = GetQueryTime(q, KeyEndTime)
 	if err != nil {
@@ -86,6 +87,7 @@ func (p *AggregateParams) ForValues(q url.Values) (err error) {
 	if p.EndTime.IsZero() {
 		p.EndTime = time.Now().UTC()
 	}
+	p.EndTime = p.EndTime.Round(TransactionRoundDuration)
 
 	p.IntervalSize, err = GetQueryInterval(q, KeyIntervalSize)
 	if err != nil {
@@ -108,8 +110,8 @@ func (p *AggregateParams) CacheKey() []string {
 	}
 
 	k = append(k,
-		CacheKey(KeyStartTime, RoundTime(p.StartTime, time.Hour).Unix()),
-		CacheKey(KeyEndTime, RoundTime(p.EndTime, time.Hour).Unix()),
+		CacheKey(KeyStartTime, p.StartTime.Unix()),
+		CacheKey(KeyEndTime, p.EndTime.Unix()),
 		CacheKey(KeyIntervalSize, int64(p.IntervalSize.Seconds())),
 		CacheKey(KeyChainID, strings.Join(p.ChainIDs, "|")),
 		CacheKey(KeyVersion, int64(p.Version)),
@@ -193,11 +195,13 @@ func (p *ListTransactionsParams) ForValues(q url.Values) error {
 	if err != nil {
 		return err
 	}
+	p.StartTime = p.StartTime.Round(TransactionRoundDuration)
 
 	p.EndTime, err = GetQueryTime(q, KeyEndTime)
 	if err != nil {
 		return err
 	}
+	p.EndTime = p.EndTime.Round(TransactionRoundDuration)
 
 	p.DisableGenesis, err = GetQueryBool(q, KeyDisableGenesis, false)
 	if err != nil {
@@ -224,8 +228,8 @@ func (p *ListTransactionsParams) CacheKey() []string {
 	}
 
 	k = append(k,
-		CacheKey(KeyStartTime, RoundTime(p.StartTime, time.Hour).Unix()),
-		CacheKey(KeyEndTime, RoundTime(p.EndTime, time.Hour).Unix()),
+		CacheKey(KeyStartTime, p.StartTime.Unix()),
+		CacheKey(KeyEndTime, p.EndTime.Unix()),
 		CacheKey(KeyChainID, strings.Join(p.ChainIDs, "|")),
 		CacheKey(KeyDisableGenesis, p.DisableGenesis),
 	)

--- a/services/indexes/params/params.go
+++ b/services/indexes/params/params.go
@@ -57,6 +57,8 @@ var (
 
 	// Ensure params types satisfy the interface
 	_ Param = &ListParams{}
+
+	TransactionRoundDuration = time.Second
 )
 
 type Param interface {
@@ -66,12 +68,6 @@ type Param interface {
 
 func CacheKey(name string, val interface{}) string {
 	return fmt.Sprintf("%s=%v", name, val)
-}
-
-func RoundTime(t time.Time, precision time.Duration) time.Time {
-	ts := t.Unix()
-	ts -= (ts % int64(precision.Seconds()))
-	return time.Unix(ts, 0)
 }
 
 //


### PR DESCRIPTION
Reverts ava-labs/ortelius#130

PR to re-implement 1 second rounding for start/end times.