### PR TITLE
Bug: capture errors and percolate

### DIFF
--- a/services/indexes/avm/writer.go
+++ b/services/indexes/avm/writer.go
@@ -258,7 +258,7 @@ func (w *Writer) insertCreateAssetTx(ctx services.ConsumerCtx, txBytes []byte, t
 		case *secp256k1fx.TransferOutput:
 			errs.Add(w.avax.InsertOutput(ctx, tx.ID(), outputCount, txOut.AssetID(), xOutOut, models.OutputTypesSECP2556K1Transfer, 0, nil))
 		default:
-			_ = ctx.Job().EventErr("assertion_to_output", errors.New("output is not known"))
+			return ctx.Job().EventErr("assertion_to_output", errors.New("output is not known"))
 		}
 		outputCount++
 	}
@@ -281,10 +281,10 @@ func (w *Writer) insertCreateAssetTx(ctx services.ConsumerCtx, txBytes []byte, t
 				}
 				errs.Add(w.avax.InsertOutput(ctx, tx.ID(), outputCount, tx.ID(), typedOut, models.OutputTypesSECP2556K1Transfer, 0, nil))
 				if amount, err = avalancheMath.Add64(amount, typedOut.Amount()); err != nil {
-					_ = ctx.Job().EventErr("add_to_amount", err)
+					return ctx.Job().EventErr("add_to_amount", err)
 				}
 			default:
-				_ = ctx.Job().EventErr("assertion_to_output", errors.New("output is not known"))
+				return ctx.Job().EventErr("assertion_to_output", errors.New("output is not known"))
 			}
 
 			outputCount++
@@ -308,5 +308,5 @@ func (w *Writer) insertCreateAssetTx(ctx services.ConsumerCtx, txBytes []byte, t
 
 	errs.Add(w.avax.InsertTransaction(ctx, txBytes, tx.UnsignedBytes(), &tx.BaseTx.BaseTx, creds, models.TransactionTypeCreateAsset, nil, nil, totalout, genesis))
 
-	return nil
+	return errs.Err
 }

--- a/services/indexes/pvm/writer.go
+++ b/services/indexes/pvm/writer.go
@@ -197,14 +197,20 @@ func (w *Writer) indexBlock(ctx services.ConsumerCtx, blockBytes []byte) error {
 func (w *Writer) indexCommonBlock(ctx services.ConsumerCtx, blkType models.BlockType, blk platformvm.CommonBlock, blockBytes []byte) error {
 	blkID := ids.NewID(hashing.ComputeHash256Array(blockBytes))
 
-	_, err := ctx.DB().
+	blockInsert := ctx.DB().
 		InsertInto("pvm_blocks").
 		Pair("id", blkID.String()).
 		Pair("chain_id", w.chainID).
 		Pair("type", blkType).
 		Pair("parent_id", blk.ParentID().String()).
-		Pair("serialization", blockBytes).
-		Pair("created_at", ctx.Time()).
+		Pair("created_at", ctx.Time())
+
+	if len(blockBytes) <= 32000 {
+		blockInsert = blockInsert.Pair("serialization", blockBytes)
+	} else {
+		blockInsert = blockInsert.Pair("serialization", []byte(""))
+	}
+	_, err := blockInsert.
 		ExecContext(ctx.Ctx())
 	if err != nil && !errIsDuplicateEntryError(err) {
 		return ctx.Job().EventErr("index_common_block.upsert_block", err)

--- a/services/indexes/pvm/writer.go
+++ b/services/indexes/pvm/writer.go
@@ -188,9 +188,10 @@ func (w *Writer) indexBlock(ctx services.ConsumerCtx, blockBytes []byte) error {
 	case *platformvm.Commit:
 		errs.Add(w.indexCommonBlock(ctx, models.BlockTypeCommit, blk.CommonBlock, blockBytes))
 	default:
-		ctx.Job().EventErr("index_block", ErrUnknownBlockType)
+		return ctx.Job().EventErr("index_block", ErrUnknownBlockType)
 	}
-	return nil
+
+	return errs.Err
 }
 
 func (w *Writer) indexCommonBlock(ctx services.ConsumerCtx, blkType models.BlockType, blk platformvm.CommonBlock, blockBytes []byte) error {


### PR DESCRIPTION
Ensure that errors insert p/x records can be rolled back if they fail.
