### PR TITLE
Bug: use chainid when querying on the /x url

### DIFF
--- a/api/v2.go
+++ b/api/v2.go
@@ -182,7 +182,7 @@ func (c *V2Context) GetAddress(w web.ResponseWriter, r *web.Request) {
 		TTL: 1 * time.Second,
 		Key: c.cacheKeyForParams("get_address", p),
 		CacheableFn: func(ctx context.Context) (interface{}, error) {
-			return c.avaxReader.GetAddress(ctx, id)
+			return c.avaxReader.GetAddress(ctx, p)
 		},
 	})
 }

--- a/api/v2.go
+++ b/api/v2.go
@@ -135,6 +135,7 @@ func (c *V2Context) ListAddresses(w web.ResponseWriter, r *web.Request) {
 		c.WriteErr(w, 400, err)
 		return
 	}
+	p.ForValueChainID(c.chainID)
 
 	c.WriteCacheable(w, Cacheable{
 		TTL: 5 * time.Second,
@@ -162,15 +163,24 @@ func (c *V2Context) AddressChains(w web.ResponseWriter, r *web.Request) {
 }
 
 func (c *V2Context) GetAddress(w web.ResponseWriter, r *web.Request) {
+	p := &params.ListAddressesParams{}
+	if err := p.ForValues(c.version, r.URL.Query()); err != nil {
+		c.WriteErr(w, 400, err)
+		return
+	}
+
 	id, err := params.AddressFromString(r.PathParams["id"])
 	if err != nil {
 		c.WriteErr(w, 400, err)
 		return
 	}
+	p.Address = &id
+	p.ListParams.DisableCounting = true
+	p.ForValueChainID(c.chainID)
 
 	c.WriteCacheable(w, Cacheable{
 		TTL: 1 * time.Second,
-		Key: c.cacheKeyForID("get_address", r.PathParams["id"]),
+		Key: c.cacheKeyForParams("get_address", p),
 		CacheableFn: func(ctx context.Context) (interface{}, error) {
 			return c.avaxReader.GetAddress(ctx, id)
 		},

--- a/services/indexes/avax/reader.go
+++ b/services/indexes/avax/reader.go
@@ -467,12 +467,8 @@ func (r *Reader) GetTransaction(ctx context.Context, id ids.ID, avaxAssetID ids.
 	return nil, nil
 }
 
-func (r *Reader) GetAddress(ctx context.Context, id ids.ShortID) (*models.AddressInfo, error) {
-	addressList, err := r.ListAddresses(ctx,
-		&params.ListAddressesParams{
-			Address:    &id,
-			ListParams: params.ListParams{DisableCounting: true},
-		})
+func (r *Reader) GetAddress(ctx context.Context, p *params.ListAddressesParams) (*models.AddressInfo, error) {
+	addressList, err := r.ListAddresses(ctx, p)
 	if err != nil {
 		return nil, err
 	}

--- a/services/indexes/params/collections.go
+++ b/services/indexes/params/collections.go
@@ -269,7 +269,20 @@ func (p *ListAddressesParams) ForValueChainID(chainID *ids.ID) {
 	if p.ChainIDs == nil {
 		p.ChainIDs = make([]string, 0, 1)
 	}
-	p.ChainIDs = append(p.ChainIDs, (*chainID).String())
+
+	cnew := chainID.String()
+
+	var found bool
+	for _, cval := range p.ChainIDs {
+		if cval == cnew {
+			found = true
+			break
+		}
+	}
+	if found {
+		return
+	}
+	p.ChainIDs = append(p.ChainIDs, cnew)
 }
 
 func (p *ListAddressesParams) ForValues(v uint8, q url.Values) error {

--- a/services/indexes/params/collections.go
+++ b/services/indexes/params/collections.go
@@ -262,6 +262,16 @@ type ListAddressesParams struct {
 	Version    int
 }
 
+func (p *ListAddressesParams) ForValueChainID(chainID *ids.ID) {
+	if chainID == nil {
+		return
+	}
+	if p.ChainIDs == nil {
+		p.ChainIDs = make([]string, 0, 1)
+	}
+	p.ChainIDs = append(p.ChainIDs, (*chainID).String())
+}
+
 func (p *ListAddressesParams) ForValues(v uint8, q url.Values) error {
 	if err := p.ListParams.ForValues(v, q); err != nil {
 		return err


### PR DESCRIPTION
When the /x endpoint is in use, the x-chain id should be applied to limit the results to just X.

Local output:

```
curl -X POST --data '{
>     "jsonrpc":"2.0",
>     "id"     :1,
>     "method" :"avm.getBalance",
>     "params" :{
>         "address":"X-avax1g6mdpx3rrv768cvp34xzfhpkx0xk23r6ahrru4",
>         "assetID"  :"AVAX"
>     }
> }' -H 'content-type:application/json;' https://api.avax.network/ext/bc/X
{"jsonrpc":"2.0","result":{"balance":"0","utxoIDs":[]},"id":1}

```

![image](https://user-images.githubusercontent.com/67973730/99297030-ac980400-2815-11eb-801b-f38de92ff390.png)
