### PR TITLE
Bug: Process next message timeout context deadline

### DIFF
--- a/stream/consumer.go
+++ b/stream/consumer.go
@@ -125,7 +125,9 @@ func (c *consumer) Close() error {
 func (c *consumer) ProcessNextMessage() error {
 	msg, err := c.nextMessage()
 	if err != nil {
-		c.conns.Logger().Error("consumer.getNextMessage: %s", err.Error())
+		if err != context.DeadlineExceeded {
+			c.conns.Logger().Error("consumer.getNextMessage: %s", err.Error())
+		}
 		return err
 	}
 

--- a/stream/consumer.go
+++ b/stream/consumer.go
@@ -102,7 +102,7 @@ func NewConsumerFactory(factory serviceConsumerFactory) ProcessorFactory {
 
 		// If the start time is set then seek to the correct offset
 		if !conf.Consumer.StartTime.IsZero() {
-			ctx, cancelFn := context.WithDeadline(context.Background(), time.Now().Add(kafkaReadTimeout))
+			ctx, cancelFn := context.WithTimeout(context.Background(), kafkaReadTimeout)
 			defer cancelFn()
 
 			if err = c.reader.SetOffsetAt(ctx, conf.Consumer.StartTime); err != nil {

--- a/stream/producer.go
+++ b/stream/producer.go
@@ -4,7 +4,6 @@
 package stream
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/ava-labs/avalanchego/utils/logging"
@@ -69,7 +68,7 @@ func (p *Producer) Close() error {
 
 // ProcessNextMessage takes in a Message from the IPC socket and writes it to
 // Kafka
-func (p *Producer) ProcessNextMessage(_ context.Context) error {
+func (p *Producer) ProcessNextMessage() error {
 	rawMsg, err := p.sock.Recv()
 	if err != nil {
 		p.log.Error("sock.Recv: %s", err.Error())

--- a/stream/write_buffer.go
+++ b/stream/write_buffer.go
@@ -101,7 +101,7 @@ func (wb *bufferedWriter) loop(size int, flushInterval time.Duration) {
 			buffer2[bpos].Key = hashing.ComputeHash256(buffer2[bpos].Value)
 		}
 
-		ctx, cancelFn := context.WithDeadline(context.Background(), time.Now().Add(defaultWriteTimeout))
+		ctx, cancelFn := context.WithTimeout(context.Background(), defaultWriteTimeout)
 		defer cancelFn()
 
 		collectors := metrics.NewCollectors(


### PR DESCRIPTION
The context applies to the kafka fetch and the db update.

Example -- If the the timeout is 10 seconds, and the kafka fetch pulls items on 9.5 seconds.  Then the db only has .5 seconds to complete.  Which can cause false context deadline on the DB update..  