### PR TITLE
Bug: Identify in/out source/dest chain and expose to endpoints

### DIFF
--- a/services/db/migrations/015_add_fields_redeem_chain.down.sql
+++ b/services/db/migrations/015_add_fields_redeem_chain.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `avm_outputs_redeeming` DROP COLUMN chain_id;

--- a/services/db/migrations/015_add_fields_redeem_chain.up.sql
+++ b/services/db/migrations/015_add_fields_redeem_chain.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `avm_outputs_redeeming` ADD COLUMN chain_id varchar(50); 

--- a/services/db/migrations/015_add_fields_redeem_chain.up.sql
+++ b/services/db/migrations/015_add_fields_redeem_chain.up.sql
@@ -1,1 +1,1 @@
-ALTER TABLE `avm_outputs_redeeming` ADD COLUMN chain_id varchar(50); 
+ALTER TABLE `avm_outputs_redeeming` ADD COLUMN chain_id varchar(50) default '';

--- a/services/indexes/avax/reader.go
+++ b/services/indexes/avax/reader.go
@@ -925,7 +925,7 @@ func selectOutputsRedeeming(dbRunner dbr.SessionRunner) *dbr.SelectBuilder {
 		"case when avm_output_addresses.address is null then '' else avm_output_addresses.address end AS address",
 		"avm_output_addresses.redeeming_signature AS signature",
 		"addresses.public_key AS public_key",
-		"case when avm_outputs.chain_id is null then '' else avm_outputs.chain_id end as chain_id",
+		"avm_outputs_redeeming.chain_id",
 	).
 		From("avm_outputs_redeeming").
 		LeftJoin("avm_outputs", "avm_outputs_redeeming.id = avm_outputs.id").

--- a/services/indexes/avax/reader.go
+++ b/services/indexes/avax/reader.go
@@ -717,7 +717,9 @@ func (r *Reader) collectInsAndOuts(ctx context.Context, dbRunner dbr.SessionRunn
 		"union_q.output_id",
 		"union_q.address",
 		"union_q.signature",
-		"union_q.public_key").
+		"union_q.public_key",
+		"union_q.chain_id",
+	).
 		From(su).
 		LoadContext(ctx, &outputs)
 	if err != nil {
@@ -897,6 +899,7 @@ func selectOutputs(dbRunner dbr.SessionRunner) *dbr.SelectBuilder {
 		"avm_output_addresses.address AS address",
 		"avm_output_addresses.redeeming_signature AS signature",
 		"addresses.public_key AS public_key",
+		"avm_outputs.chain_id",
 	).
 		From("avm_outputs").
 		LeftJoin("avm_output_addresses", "avm_outputs.id = avm_output_addresses.output_id").
@@ -922,6 +925,7 @@ func selectOutputsRedeeming(dbRunner dbr.SessionRunner) *dbr.SelectBuilder {
 		"case when avm_output_addresses.address is null then '' else avm_output_addresses.address end AS address",
 		"avm_output_addresses.redeeming_signature AS signature",
 		"addresses.public_key AS public_key",
+		"case when avm_outputs.chain_id is null then '' else avm_outputs.chain_id end as chain_id",
 	).
 		From("avm_outputs_redeeming").
 		LeftJoin("avm_outputs", "avm_outputs_redeeming.id = avm_outputs.id").

--- a/services/indexes/avax/writer.go
+++ b/services/indexes/avax/writer.go
@@ -158,7 +158,7 @@ func (w *Writer) insertTransactionIns(idx int, ctx services.ConsumerCtx, errs wr
 			w.InsertOutputAddress(ctx, inputID, publicKey.Address(), sig[:]),
 		)
 	}
-	return totalin, err
+	return totalin, nil
 }
 
 func (w *Writer) insertTransactionOuts(idx int, ctx services.ConsumerCtx, errs wrappers.Errs, totalout uint64, out *avax.TransferableOutput, baseTx *avax.BaseTx, chainID string) (uint64, error) {
@@ -188,7 +188,7 @@ func (w *Writer) insertTransactionOuts(idx int, ctx services.ConsumerCtx, errs w
 	default:
 		errs.Add(fmt.Errorf("unknown type %s", reflect.TypeOf(transferOutput)))
 	}
-	return totalout, err
+	return totalout, nil
 }
 
 func (w *Writer) InsertOutput(ctx services.ConsumerCtx, txID ids.ID, idx uint32, assetID ids.ID, out *secp256k1fx.TransferOutput, outputType models.OutputType, groupID uint32, payload []byte, stakeLocktime uint64, chainID string) error {

--- a/services/indexes/avm/writer.go
+++ b/services/indexes/avm/writer.go
@@ -228,13 +228,13 @@ func (w *Writer) insertTx(ctx services.ConsumerCtx, txBytes []byte) error {
 				addlOuts = append(addlOuts, &transferableOutput)
 			}
 		}
-		return w.avax.InsertTransaction(ctx, txBytes, unsignedBytes, &castTx.BaseTx.BaseTx, tx.Credentials(), models.TransactionTypeOperation, nil, addlOuts, 0, false)
+		return w.avax.InsertTransaction(ctx, txBytes, unsignedBytes, &castTx.BaseTx.BaseTx, tx.Credentials(), models.TransactionTypeOperation, nil, addlOuts, w.chainID, 0, false)
 	case *avm.ImportTx:
-		return w.avax.InsertTransaction(ctx, txBytes, unsignedBytes, &castTx.BaseTx.BaseTx, tx.Credentials(), models.TransactionTypeAVMImport, castTx.ImportedIns, nil, 0, false)
+		return w.avax.InsertTransaction(ctx, txBytes, unsignedBytes, &castTx.BaseTx.BaseTx, tx.Credentials(), models.TransactionTypeAVMImport, castTx.ImportedIns, nil, w.chainID, 0, false)
 	case *avm.ExportTx:
-		return w.avax.InsertTransaction(ctx, txBytes, unsignedBytes, &castTx.BaseTx.BaseTx, tx.Credentials(), models.TransactionTypeAVMExport, nil, castTx.ExportedOuts, 0, false)
+		return w.avax.InsertTransaction(ctx, txBytes, unsignedBytes, &castTx.BaseTx.BaseTx, tx.Credentials(), models.TransactionTypeAVMExport, nil, castTx.ExportedOuts, castTx.DestinationChain.String(), 0, false)
 	case *avm.BaseTx:
-		return w.avax.InsertTransaction(ctx, txBytes, unsignedBytes, &castTx.BaseTx, tx.Credentials(), models.TransactionTypeBase, nil, nil, 0, false)
+		return w.avax.InsertTransaction(ctx, txBytes, unsignedBytes, &castTx.BaseTx, tx.Credentials(), models.TransactionTypeBase, nil, nil, w.chainID, 0, false)
 	default:
 		return errors.New("unknown tx type")
 	}
@@ -256,7 +256,7 @@ func (w *Writer) insertCreateAssetTx(ctx services.ConsumerCtx, txBytes []byte, t
 	for _, txOut := range tx.Outs {
 		switch xOutOut := txOut.Out.(type) {
 		case *secp256k1fx.TransferOutput:
-			errs.Add(w.avax.InsertOutput(ctx, tx.ID(), outputCount, txOut.AssetID(), xOutOut, models.OutputTypesSECP2556K1Transfer, 0, nil, 0))
+			errs.Add(w.avax.InsertOutput(ctx, tx.ID(), outputCount, txOut.AssetID(), xOutOut, models.OutputTypesSECP2556K1Transfer, 0, nil, 0, w.chainID))
 		default:
 			return ctx.Job().EventErr("assertion_to_output", errors.New("output is not known"))
 		}
@@ -267,11 +267,11 @@ func (w *Writer) insertCreateAssetTx(ctx services.ConsumerCtx, txBytes []byte, t
 		for _, out := range state.Outs {
 			switch typedOut := out.(type) {
 			case *nftfx.TransferOutput:
-				errs.Add(w.avax.InsertOutput(ctx, tx.ID(), outputCount, tx.ID(), xOut(typedOut.OutputOwners), models.OutputTypesNFTTransfer, typedOut.GroupID, typedOut.Payload, 0))
+				errs.Add(w.avax.InsertOutput(ctx, tx.ID(), outputCount, tx.ID(), xOut(typedOut.OutputOwners), models.OutputTypesNFTTransfer, typedOut.GroupID, typedOut.Payload, 0, w.chainID))
 			case *nftfx.MintOutput:
-				errs.Add(w.avax.InsertOutput(ctx, tx.ID(), outputCount, tx.ID(), xOut(typedOut.OutputOwners), models.OutputTypesNFTMint, typedOut.GroupID, nil, 0))
+				errs.Add(w.avax.InsertOutput(ctx, tx.ID(), outputCount, tx.ID(), xOut(typedOut.OutputOwners), models.OutputTypesNFTMint, typedOut.GroupID, nil, 0, w.chainID))
 			case *secp256k1fx.MintOutput:
-				errs.Add(w.avax.InsertOutput(ctx, tx.ID(), outputCount, tx.ID(), xOut(typedOut.OutputOwners), models.OutputTypesSECP2556K1Mint, 0, nil, 0))
+				errs.Add(w.avax.InsertOutput(ctx, tx.ID(), outputCount, tx.ID(), xOut(typedOut.OutputOwners), models.OutputTypesSECP2556K1Mint, 0, nil, 0, w.chainID))
 			case *secp256k1fx.TransferOutput:
 				if tx.ID().Equals(w.avaxAssetID) {
 					totalout, err = avalancheMath.Add64(totalout, typedOut.Amt)
@@ -279,7 +279,7 @@ func (w *Writer) insertCreateAssetTx(ctx services.ConsumerCtx, txBytes []byte, t
 						errs.Add(err)
 					}
 				}
-				errs.Add(w.avax.InsertOutput(ctx, tx.ID(), outputCount, tx.ID(), typedOut, models.OutputTypesSECP2556K1Transfer, 0, nil, 0))
+				errs.Add(w.avax.InsertOutput(ctx, tx.ID(), outputCount, tx.ID(), typedOut, models.OutputTypesSECP2556K1Transfer, 0, nil, 0, w.chainID))
 				if amount, err = avalancheMath.Add64(amount, typedOut.Amount()); err != nil {
 					return ctx.Job().EventErr("add_to_amount", err)
 				}
@@ -306,7 +306,7 @@ func (w *Writer) insertCreateAssetTx(ctx services.ConsumerCtx, txBytes []byte, t
 		return err
 	}
 
-	errs.Add(w.avax.InsertTransaction(ctx, txBytes, tx.UnsignedBytes(), &tx.BaseTx.BaseTx, creds, models.TransactionTypeCreateAsset, nil, nil, totalout, genesis))
+	errs.Add(w.avax.InsertTransaction(ctx, txBytes, tx.UnsignedBytes(), &tx.BaseTx.BaseTx, creds, models.TransactionTypeCreateAsset, nil, nil, w.chainID, totalout, genesis))
 
 	return errs.Err
 }

--- a/services/indexes/avm/writer.go
+++ b/services/indexes/avm/writer.go
@@ -228,13 +228,13 @@ func (w *Writer) insertTx(ctx services.ConsumerCtx, txBytes []byte) error {
 				addlOuts = append(addlOuts, &transferableOutput)
 			}
 		}
-		return w.avax.InsertTransaction(ctx, txBytes, unsignedBytes, &castTx.BaseTx.BaseTx, tx.Credentials(), models.TransactionTypeOperation, nil, addlOuts, w.chainID, 0, false)
+		return w.avax.InsertTransaction(ctx, txBytes, unsignedBytes, &castTx.BaseTx.BaseTx, tx.Credentials(), models.TransactionTypeOperation, nil, w.chainID, addlOuts, w.chainID, 0, false)
 	case *avm.ImportTx:
-		return w.avax.InsertTransaction(ctx, txBytes, unsignedBytes, &castTx.BaseTx.BaseTx, tx.Credentials(), models.TransactionTypeAVMImport, castTx.ImportedIns, nil, w.chainID, 0, false)
+		return w.avax.InsertTransaction(ctx, txBytes, unsignedBytes, &castTx.BaseTx.BaseTx, tx.Credentials(), models.TransactionTypeAVMImport, castTx.ImportedIns, castTx.SourceChain.String(), nil, w.chainID, 0, false)
 	case *avm.ExportTx:
-		return w.avax.InsertTransaction(ctx, txBytes, unsignedBytes, &castTx.BaseTx.BaseTx, tx.Credentials(), models.TransactionTypeAVMExport, nil, castTx.ExportedOuts, castTx.DestinationChain.String(), 0, false)
+		return w.avax.InsertTransaction(ctx, txBytes, unsignedBytes, &castTx.BaseTx.BaseTx, tx.Credentials(), models.TransactionTypeAVMExport, nil, w.chainID, castTx.ExportedOuts, castTx.DestinationChain.String(), 0, false)
 	case *avm.BaseTx:
-		return w.avax.InsertTransaction(ctx, txBytes, unsignedBytes, &castTx.BaseTx, tx.Credentials(), models.TransactionTypeBase, nil, nil, w.chainID, 0, false)
+		return w.avax.InsertTransaction(ctx, txBytes, unsignedBytes, &castTx.BaseTx, tx.Credentials(), models.TransactionTypeBase, nil, w.chainID, nil, w.chainID, 0, false)
 	default:
 		return errors.New("unknown tx type")
 	}
@@ -306,7 +306,7 @@ func (w *Writer) insertCreateAssetTx(ctx services.ConsumerCtx, txBytes []byte, t
 		return err
 	}
 
-	errs.Add(w.avax.InsertTransaction(ctx, txBytes, tx.UnsignedBytes(), &tx.BaseTx.BaseTx, creds, models.TransactionTypeCreateAsset, nil, nil, w.chainID, totalout, genesis))
+	errs.Add(w.avax.InsertTransaction(ctx, txBytes, tx.UnsignedBytes(), &tx.BaseTx.BaseTx, creds, models.TransactionTypeCreateAsset, nil, w.chainID, nil, w.chainID, totalout, genesis))
 
 	return errs.Err
 }

--- a/services/indexes/models/avax.go
+++ b/services/indexes/models/avax.go
@@ -51,6 +51,8 @@ type Output struct {
 
 	RedeemingTransactionID StringID `json:"redeemingTransactionID"`
 
+	ChainID StringID `json:"chainID"`
+
 	Score uint64 `json:"-"`
 }
 

--- a/services/indexes/pvm/writer.go
+++ b/services/indexes/pvm/writer.go
@@ -227,6 +227,7 @@ func (w *Writer) indexTransaction(ctx services.ConsumerCtx, _ ids.ID, tx platfor
 	var outs []*avax.TransferableOutput
 
 	outChain := w.chainID
+	inChain := w.chainID
 
 	switch castTx := tx.UnsignedTx.(type) {
 	case *platformvm.UnsignedAddValidatorTx:
@@ -249,6 +250,7 @@ func (w *Writer) indexTransaction(ctx services.ConsumerCtx, _ ids.ID, tx platfor
 	case *platformvm.UnsignedImportTx:
 		baseTx = castTx.BaseTx.BaseTx
 		ins = castTx.ImportedInputs
+		inChain = castTx.SourceChain.String()
 		typ = models.TransactionTypePVMImport
 	case *platformvm.UnsignedExportTx:
 		baseTx = castTx.BaseTx.BaseTx
@@ -261,5 +263,5 @@ func (w *Writer) indexTransaction(ctx services.ConsumerCtx, _ ids.ID, tx platfor
 		return nil
 	}
 
-	return w.avax.InsertTransaction(ctx, tx.Bytes(), tx.UnsignedBytes(), &baseTx, tx.Creds, typ, ins, outs, outChain, 0, genesis)
+	return w.avax.InsertTransaction(ctx, tx.Bytes(), tx.UnsignedBytes(), &baseTx, tx.Creds, typ, ins, inChain, outs, outChain, 0, genesis)
 }


### PR DESCRIPTION
Dress the exported outs and imported ins as the appropriate chainid..  And expose chainid in the outputs to the caller.