### PR TITLE
Dress the processor logging line with a unique identifier

### DIFF
--- a/stream/consumer.go
+++ b/stream/consumer.go
@@ -34,6 +34,7 @@ type serviceConsumerFactory func(*services.Connections, uint32, string, string) 
 
 // consumer takes events from Kafka and sends them to a service consumer
 type consumer struct {
+	id       string
 	chainID  string
 	reader   *kafka.Reader
 	consumer services.Consumer
@@ -61,6 +62,7 @@ func NewConsumerFactory(factory serviceConsumerFactory) ProcessorFactory {
 			metricProcessMillisCounterKey: fmt.Sprintf("consume_records_process_millis_%s", chainID),
 			metricSuccessCountKey:         fmt.Sprintf("consume_records_success_%s", chainID),
 			metricFailureCountKey:         fmt.Sprintf("consume_records_failure_%s", chainID),
+			id:                            fmt.Sprintf("consumer %d %s %s", conf.NetworkID, chainVM, chainID),
 		}
 		metrics.Prometheus.CounterInit(c.metricProcessedCountKey, "records processed")
 		metrics.Prometheus.CounterInit(c.metricProcessMillisCounterKey, "records processed millis")
@@ -112,6 +114,10 @@ func NewConsumerFactory(factory serviceConsumerFactory) ProcessorFactory {
 
 		return c, nil
 	}
+}
+
+func (c *consumer) ID() string {
+	return c.id
 }
 
 // Close closes the consumer

--- a/stream/processor.go
+++ b/stream/processor.go
@@ -33,6 +33,7 @@ type Processor interface {
 	Close() error
 	Failure()
 	Success()
+	ID() string
 }
 
 // ProcessorManager supervises the Processor lifecycle; it will use the given
@@ -170,12 +171,14 @@ func (c *ProcessorManager) runProcessor(chainConfig cfg.Chain) error {
 		}
 	)
 
+	id := backend.ID()
+
 	// Log run statistics periodically until asked to stop
 	go func() {
 		t := time.NewTicker(30 * time.Second)
 		defer t.Stop()
 		for range t.C {
-			c.log.Info("IProcessor successes=%d failures=%d nomsg=%d", successes, failures, nomsg)
+			c.log.Info("IProcessor %s successes=%d failures=%d nomsg=%d", id, successes, failures, nomsg)
 			if c.isStopping() {
 				return
 			}

--- a/stream/producer.go
+++ b/stream/producer.go
@@ -15,6 +15,7 @@ import (
 
 // producer reads from the socket and writes to the event stream
 type Producer struct {
+	id          string
 	chainID     string
 	eventType   EventType
 	sock        *socket.Client
@@ -37,6 +38,7 @@ func NewProducer(conf cfg.Config, _ string, chainID string, eventType EventType)
 		metricProcessedCountKey: fmt.Sprintf("produce_records_processed_%s_%s", chainID, eventType),
 		metricSuccessCountKey:   fmt.Sprintf("produce_records_success_%s_%s", chainID, eventType),
 		metricFailureCountKey:   fmt.Sprintf("produce_records_failure_%s_%s", chainID, eventType),
+		id:                      fmt.Sprintf("producer %d %s %s", conf.NetworkID, chainID, eventType),
 	}
 	metrics.Prometheus.CounterInit(p.metricProcessedCountKey, "records processed")
 	metrics.Prometheus.CounterInit(p.metricSuccessCountKey, "records success")
@@ -64,6 +66,10 @@ func NewDecisionsProducerProcessor(conf cfg.Config, chainVM string, chainID stri
 // Close shuts down the producer
 func (p *Producer) Close() error {
 	return p.writeBuffer.close()
+}
+
+func (p *Producer) ID() string {
+	return p.id
 }
 
 // ProcessNextMessage takes in a Message from the IPC socket and writes it to


### PR DESCRIPTION
Easier to distinguish these lines:

`INFO [11-20|23:22:28] /go/src/github.com/ava-labs/ortelius/stream/processor.go#178: IProcessor successes=230083 failures=0 nomsg=0`
