### PR TITLE
Refactor aggregate params on asset endpoints - enable by specific interval

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -114,7 +114,7 @@ The transaction object
 
 `disableCount` - Bool value = true will suppress counting in results, count will be 0 in results
 
-`enableAggregate` - Bool value = true will include aggregates for minute, hour, day, week, month, year (from aggregate cache - not real time)
+`enableAggregate` - String values in [minute, hour, day, week, month, year]
 
 #### Response:
 

--- a/services/indexes/avm/reader.go
+++ b/services/indexes/avm/reader.go
@@ -111,11 +111,11 @@ func (r *Reader) dressAssets(ctx context.Context, dbRunner dbr.SessionRunner, as
 
 		asset.Aggregates = make(map[string]*models.Aggregates)
 
-		for _, aggDuration := range p.EnableAggregate {
+		for _, intervalName := range p.EnableAggregate {
 			aparams := params.AggregateParams{
 				ListParams:   p.ListParams,
 				AssetID:      &id,
-				IntervalSize: params.IntervalNames[aggDuration],
+				IntervalSize: params.IntervalNames[intervalName],
 				Version:      1,
 			}
 			hm, err := r.avaxReader.Aggregate(ctx, &aparams)
@@ -123,7 +123,7 @@ func (r *Reader) dressAssets(ctx context.Context, dbRunner dbr.SessionRunner, as
 				r.conns.Logger().Warn("aggregate query failed %s", err)
 				continue
 			}
-			asset.Aggregates[aggDuration] = &hm.Aggregates
+			asset.Aggregates[intervalName] = &hm.Aggregates
 		}
 	}
 

--- a/services/indexes/params/collections.go
+++ b/services/indexes/params/collections.go
@@ -257,7 +257,7 @@ func (p *ListTransactionsParams) Apply(b *dbr.SelectBuilder) *dbr.SelectBuilder 
 type ListAssetsParams struct {
 	ListParams      ListParams
 	Alias           string
-	EnableAggregate bool
+	EnableAggregate []string
 	PathParamID     string
 }
 
@@ -268,10 +268,17 @@ func (p *ListAssetsParams) ForValues(v uint8, q url.Values) error {
 
 	p.Alias = GetQueryString(q, KeyAlias, "")
 
-	var err error
-	p.EnableAggregate, err = GetQueryBool(q, KeyEnableAggregate, false)
-	if err != nil {
-		return err
+	for _, enableAgg := range q[KeyEnableAggregate] {
+		qq := make(url.Values)
+		qq[KeyIntervalSize] = []string{enableAgg}
+		_, err := GetQueryInterval(qq, KeyIntervalSize)
+		if err != nil {
+			return err
+		}
+		if p.EnableAggregate == nil {
+			p.EnableAggregate = make([]string, 0, 1)
+		}
+		p.EnableAggregate = append(p.EnableAggregate, enableAgg)
 	}
 
 	return nil


### PR DESCRIPTION
For /assets allow params enableAggregate=[minute|hour|day...] multiple can be specified.
And the startTime/endTime params (now in ListParams) will be passed to Aggregates.