### PR TITLE
Variable cap asset check is not hitting an index

### DIFF
--- a/services/db/migrations/017_mint_outputs.down.sql
+++ b/services/db/migrations/017_mint_outputs.down.sql
@@ -1,0 +1,3 @@
+create index `avm_outputs_asset_id` ON `avm_outputs` (asset_id);
+drop index `avm_outputs_asset_id_output_type` on `avm_outputs`;
+

--- a/services/db/migrations/017_mint_outputs.up.sql
+++ b/services/db/migrations/017_mint_outputs.up.sql
@@ -1,0 +1,3 @@
+create index `avm_outputs_asset_id_output_type` ON `avm_outputs` (asset_id,output_type);
+drop index `avm_outputs_asset_id` on `avm_outputs`;
+


### PR DESCRIPTION
here:
https://github.com/ava-labs/ortelius/blob/3431643ee775a572917171f92f8dc247a6dc0dfe/services/indexes/avm/reader.go#L135

Add an index on asset_id and type and remove the one on just asset_id..

