### PR TITLE
Use a subquery to find the ID

### DIFF
--- a/services/indexes/avax/reader.go
+++ b/services/indexes/avax/reader.go
@@ -453,6 +453,24 @@ func (r *Reader) ListTransactions(ctx context.Context, p *params.ListTransaction
 
 	subquery := p.Apply(dbRunner.Select("id").From("avm_transactions"))
 
+	var applySort2 func(sort params.TransactionSort)
+	applySort2 = func(sort params.TransactionSort) {
+		if p.ListParams.Query != "" {
+			return
+		}
+		switch sort {
+		case params.TransactionSortTimestampAsc:
+			subquery.OrderAsc("avm_transactions.chain_id")
+			subquery.OrderAsc("avm_transactions.created_at")
+		case params.TransactionSortTimestampDesc:
+			subquery.OrderAsc("avm_transactions.chain_id")
+			subquery.OrderDesc("avm_transactions.created_at")
+		default:
+			applySort2(params.TransactionSortDefault)
+		}
+	}
+	applySort2(p.Sort)
+
 	var txs []*models.Transaction
 	builder := dbRunner.
 		Select(

--- a/services/indexes/avax/reader.go
+++ b/services/indexes/avax/reader.go
@@ -520,10 +520,9 @@ func (r *Reader) ListTransactions(ctx context.Context, p *params.ListTransaction
 		count = uint64Ptr(uint64(p.ListParams.Offset) + uint64(len(txs)))
 		if len(txs) >= p.ListParams.Limit {
 			p.ListParams = params.ListParams{}
-			selector := dbRunner.
+			selector := p.Apply(dbRunner.
 				Select("COUNT(avm_transactions.id)").
-				From("avm_transactions").
-				Join(subquery.As("avm_transactions_id"), "avm_transactions.id = avm_transactions_id.id")
+				From("avm_transactions"))
 
 			if err := selector.LoadOneContext(ctx, &count); err != nil {
 				return nil, err

--- a/services/indexes/avax/reader.go
+++ b/services/indexes/avax/reader.go
@@ -451,10 +451,10 @@ func (r *Reader) ListTransactions(ctx context.Context, p *params.ListTransaction
 		return nil, err
 	}
 
-	subquery := p.ApplySub(dbRunner.Select("id").From("avm_transactions"))
+	subquery := p.Apply(dbRunner.Select("id").From("avm_transactions"))
 
 	var txs []*models.Transaction
-	builder := p.Apply(dbRunner.
+	builder := dbRunner.
 		Select(
 			"avm_transactions.id",
 			"avm_transactions.chain_id",
@@ -465,8 +465,7 @@ func (r *Reader) ListTransactions(ctx context.Context, p *params.ListTransaction
 			"avm_transactions.genesis",
 		).
 		From("avm_transactions").
-		Join(subquery.As("avm_transactions_id"), "avm_transactions.id = avm_transactions_id.id"),
-	)
+		Join(subquery.As("avm_transactions_id"), "avm_transactions.id = avm_transactions_id.id")
 
 	var applySort func(sort params.TransactionSort)
 	applySort = func(sort params.TransactionSort) {
@@ -495,11 +494,10 @@ func (r *Reader) ListTransactions(ctx context.Context, p *params.ListTransaction
 		count = uint64Ptr(uint64(p.ListParams.Offset) + uint64(len(txs)))
 		if len(txs) >= p.ListParams.Limit {
 			p.ListParams = params.ListParams{}
-			selector := p.Apply(dbRunner.
+			selector := dbRunner.
 				Select("COUNT(avm_transactions.id)").
 				From("avm_transactions").
-				Join(subquery.As("avm_transactions_id"), "avm_transactions.id = avm_transactions_id.id"),
-			)
+				Join(subquery.As("avm_transactions_id"), "avm_transactions.id = avm_transactions_id.id")
 
 			if err := selector.LoadOneContext(ctx, &count); err != nil {
 				return nil, err

--- a/services/indexes/avax/reader.go
+++ b/services/indexes/avax/reader.go
@@ -460,10 +460,14 @@ func (r *Reader) ListTransactions(ctx context.Context, p *params.ListTransaction
 		}
 		switch sort {
 		case params.TransactionSortTimestampAsc:
-			subquery.OrderAsc("avm_transactions.chain_id")
+			if len(p.ChainIDs) > 0 {
+				subquery.OrderAsc("avm_transactions.chain_id")
+			}
 			subquery.OrderAsc("avm_transactions.created_at")
 		case params.TransactionSortTimestampDesc:
-			subquery.OrderAsc("avm_transactions.chain_id")
+			if len(p.ChainIDs) > 0 {
+				subquery.OrderAsc("avm_transactions.chain_id")
+			}
 			subquery.OrderDesc("avm_transactions.created_at")
 		default:
 			applySort2(params.TransactionSortDefault)

--- a/services/indexes/params/collections.go
+++ b/services/indexes/params/collections.go
@@ -212,21 +212,12 @@ func (p *ListTransactionsParams) CacheKey() []string {
 	return k
 }
 
-func (p *ListTransactionsParams) ApplySub(b *dbr.SelectBuilder) *dbr.SelectBuilder {
+func (p *ListTransactionsParams) Apply(b *dbr.SelectBuilder) *dbr.SelectBuilder {
 	p.ListParams.Apply("avm_transactions", b)
 
 	if len(p.ChainIDs) > 0 {
 		b.Where("avm_transactions.chain_id = ?", p.ChainIDs)
 	}
-	return b
-}
-
-func (p *ListTransactionsParams) Apply(b *dbr.SelectBuilder) *dbr.SelectBuilder {
-	// p.ListParams.Apply("avm_transactions", b)
-
-	// if len(p.ChainIDs) > 0 {
-	// 	b.Where("avm_transactions.chain_id = ?", p.ChainIDs)
-	// }
 
 	var dosq bool
 	var dosqRedeem bool

--- a/services/indexes/params/collections.go
+++ b/services/indexes/params/collections.go
@@ -212,8 +212,17 @@ func (p *ListTransactionsParams) CacheKey() []string {
 	return k
 }
 
-func (p *ListTransactionsParams) Apply(b *dbr.SelectBuilder) *dbr.SelectBuilder {
+func (p *ListTransactionsParams) ApplySub(b *dbr.SelectBuilder) *dbr.SelectBuilder {
 	p.ListParams.Apply("avm_transactions", b)
+
+	if len(p.ChainIDs) > 0 {
+		b.Where("avm_transactions.chain_id = ?", p.ChainIDs)
+	}
+	return b
+}
+
+func (p *ListTransactionsParams) Apply(b *dbr.SelectBuilder) *dbr.SelectBuilder {
+	// p.ListParams.Apply("avm_transactions", b)
 
 	if len(p.ChainIDs) > 0 {
 		b.Where("avm_transactions.chain_id = ?", p.ChainIDs)

--- a/services/indexes/params/collections.go
+++ b/services/indexes/params/collections.go
@@ -224,9 +224,9 @@ func (p *ListTransactionsParams) ApplySub(b *dbr.SelectBuilder) *dbr.SelectBuild
 func (p *ListTransactionsParams) Apply(b *dbr.SelectBuilder) *dbr.SelectBuilder {
 	// p.ListParams.Apply("avm_transactions", b)
 
-	if len(p.ChainIDs) > 0 {
-		b.Where("avm_transactions.chain_id = ?", p.ChainIDs)
-	}
+	// if len(p.ChainIDs) > 0 {
+	// 	b.Where("avm_transactions.chain_id = ?", p.ChainIDs)
+	// }
 
 	var dosq bool
 	var dosqRedeem bool


### PR DESCRIPTION
https://explainextended.com/2009/10/23/mysql-order-by-limit-performance-late-row-lookups/

Using a subquery on the primary key significantly improves the offset lookups.

==

This query happens in < .5 sec.

SELECT avm_transactions.id, avm_transactions.chain_id, avm_transactions.type, avm_transactions.memo, avm_transactions.created_at, avm_transactions.txfee, avm_transactions.genesis
FROM avm_transactions,
     (select id from avm_transactions WHERE (avm_transactions.chain_id = ('2oYMBNV4eNHyqk2fjjV5nVQLDbtmNJzq5s3qs3Lo6ftnC6FByM')) LIMIT 1 OFFSET 172377) b
where avm_transactions.id = b.id
ORDER BY avm_transactions.chain_id ASC, avm_transactions.created_at ASC

This query takes 3+ seconds..

 SELECT avm_transactions.id, avm_transactions.chain_id, avm_transactions.type, avm_transactions.memo, avm_transactions.created_at, avm_transactions.txfee, avm_transactions.genesis
 FROM avm_transactions
 WHERE (avm_transactions.chain_id = ('2oYMBNV4eNHyqk2fjjV5nVQLDbtmNJzq5s3qs3Lo6ftnC6FByM'))
 ORDER BY avm_transactions.chain_id ASC, avm_transactions.created_at ASC LIMIT 1 OFFSET 172377



