### PR TITLE
Config update format to match cfg parse

### DIFF
--- a/docker/config.json
+++ b/docker/config.json
@@ -1,7 +1,6 @@
 {
   "networkID": 1,
   "logDirectory": "/var/log/ortelius",
-  "ipcRoot": "ipc:///tmp",
   "metricsListenAddr": "",
   "listenAddr": "localhost:8080",
   "chains": {
@@ -20,7 +19,12 @@
     "kafka": {
       "brokers": [
         "kafka:9092"
-      ],
+      ]
+    },
+    "producer": {
+      "ipcRoot": "/tmp"
+    },
+    "consumer": {
       "groupName": "indexer"
     }
   },

--- a/docker/standalone/config.standalone.json
+++ b/docker/standalone/config.standalone.json
@@ -1,7 +1,6 @@
 {
   "networkID": 5,
   "logDirectory": "/var/log/ortelius",
-  "ipcRoot": "ipc:///tmp",
   "listenAddr": "localhost:8080",
   "chains": {
     "11111111111111111111111111111111LpoYY": {
@@ -19,7 +18,12 @@
     "kafka": {
       "brokers": [
         "kafka:9092"
-      ],
+      ]
+    },
+    "producer": {
+      "ipcRoot": "/tmp"
+    },
+    "consumer": {
       "groupName": "indexer"
     }
   },


### PR DESCRIPTION
Ipc root and groupname moved accordingly.

This was working b/c the defaults were being selected
[here](https://github.com/ava-labs/ortelius/blob/7d7d339f0689d9728741ddb01d4e35c6a91f5d06/cfg/defaults.go#L24)
and
[here](https://github.com/ava-labs/ortelius/blob/7d7d339f0689d9728741ddb01d4e35c6a91f5d06/cfg/defaults.go#L27)