### PR TITLE
Save list params for use in transaction list

### DIFF
--- a/services/indexes/avax/reader.go
+++ b/services/indexes/avax/reader.go
@@ -517,6 +517,8 @@ func (r *Reader) ListTransactions(ctx context.Context, p *params.ListTransaction
 		return nil, err
 	}
 
+	listParamsOriginal := p.ListParams
+
 	var count *uint64
 	if !p.ListParams.DisableCounting {
 		count = uint64Ptr(uint64(p.ListParams.Offset) + uint64(len(txs)))
@@ -533,7 +535,7 @@ func (r *Reader) ListTransactions(ctx context.Context, p *params.ListTransaction
 	}
 
 	// Add all the addition information we might want
-	if err := r.dressTransactions(ctx, dbRunner, txs, avaxAssetID, p.ListParams.ID, p.DisableGenesis); err != nil {
+	if err := r.dressTransactions(ctx, dbRunner, txs, avaxAssetID, listParamsOriginal.ID, p.DisableGenesis); err != nil {
 		return nil, err
 	}
 
@@ -541,8 +543,8 @@ func (r *Reader) ListTransactions(ctx context.Context, p *params.ListTransaction
 		Count: count,
 	},
 		Transactions: txs,
-		StartTime:    p.ListParams.StartTime,
-		EndTime:      p.ListParams.EndTime,
+		StartTime:    listParamsOriginal.StartTime,
+		EndTime:      listParamsOriginal.EndTime,
 	}, nil
 }
 


### PR DESCRIPTION
When counting happens it overwrites p.ListParams and that resets the start/end time.
The results in ListMetadata get set back to time(0).