### PR TITLE
Dress assets if called after counting rows will have a cleared ListParams

### DIFF
--- a/services/indexes/avm/reader.go
+++ b/services/indexes/avm/reader.go
@@ -44,6 +44,11 @@ func (r *Reader) ListAssets(ctx context.Context, p *params.ListAssetsParams) (*m
 		return nil, err
 	}
 
+	// Add all the addition information we might want
+	if err = r.dressAssets(ctx, dbRunner, assets, p); err != nil {
+		return nil, err
+	}
+
 	var count *uint64
 	if !p.ListParams.DisableCounting {
 		count = uint64Ptr(uint64(p.ListParams.Offset) + uint64(len(assets)))
@@ -57,11 +62,6 @@ func (r *Reader) ListAssets(ctx context.Context, p *params.ListAssetsParams) (*m
 				return nil, err
 			}
 		}
-	}
-
-	// Add all the addition information we might want
-	if err = r.dressAssets(ctx, dbRunner, assets, p); err != nil {
-		return nil, err
 	}
 
 	return &models.AssetList{ListMetadata: models.ListMetadata{Count: count}, Assets: assets}, nil


### PR DESCRIPTION
For counting we reset ListAddressesParams.ListParams.   If that happens before dressAssets gets called the values of ListParams would be reset, and could cause different results for the dressAssets call.

[here](https://github.com/ava-labs/ortelius/blob/22db90be133403c420bc65cbf20a10e629d3aeb8/services/indexes/avm/reader.go#L51) - p.ListParams is reset for counting, but that will reset any times for the aggregate queries.