### PR TITLE
Increase the default and maximum limit to 5000

### DIFF
--- a/services/indexes/params/params.go
+++ b/services/indexes/params/params.go
@@ -32,8 +32,8 @@ const (
 	KeyVersion         = "version"
 	KeyEnableAggregate = "enableAggregate"
 
-	PaginationMaxLimit      = 500
-	PaginationDefaultLimit  = 500
+	PaginationMaxLimit      = 5000
+	PaginationDefaultLimit  = 5000
 	PaginationDefaultOffset = 0
 
 	VersionDefault = 0


### PR DESCRIPTION
Allow the limit to extend to 5000 items.