### PR TITLE
The Apply function can take a different primary key.

### DIFF
--- a/services/indexes/params/collections.go
+++ b/services/indexes/params/collections.go
@@ -357,7 +357,7 @@ func (p *ListAddressesParams) CacheKey() []string {
 }
 
 func (p *ListAddressesParams) Apply(b *dbr.SelectBuilder) *dbr.SelectBuilder {
-	b = p.ListParams.Apply("avm_output_addresses", b)
+	b = p.ListParams.ApplyPk("avm_output_addresses", b, "output_id")
 
 	if p.Address != nil {
 		b = b.

--- a/services/indexes/params/params.go
+++ b/services/indexes/params/params.go
@@ -150,6 +150,10 @@ func (p *ListParams) CacheKey() []string {
 }
 
 func (p ListParams) Apply(listTable string, b *dbr.SelectBuilder) *dbr.SelectBuilder {
+	return p.ApplyPk(listTable, b, "id")
+}
+
+func (p ListParams) ApplyPk(listTable string, b *dbr.SelectBuilder, primaryKey string) *dbr.SelectBuilder {
 	if p.Limit > PaginationMaxLimit {
 		p.Limit = PaginationMaxLimit
 	}
@@ -161,7 +165,7 @@ func (p ListParams) Apply(listTable string, b *dbr.SelectBuilder) *dbr.SelectBui
 	}
 
 	if p.ID != nil {
-		b.Where(listTable+".id = ?", p.ID.String()).Limit(1)
+		b.Where(listTable+"."+primaryKey+" = ?", p.ID.String()).Limit(1)
 	}
 
 	if p.Query != "" {


### PR DESCRIPTION
avm_output_addresses has a primary key of 'output_id'. 